### PR TITLE
feat(event-bus): implement core EventBus and add keyboard input support

### DIFF
--- a/src/client/java/vexonclient/VexonClient.java
+++ b/src/client/java/vexonclient/VexonClient.java
@@ -3,10 +3,12 @@ package vexonclient;
 import net.fabricmc.api.ClientModInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import vexonclient.events.EventBus;
 
 public class VexonClient implements ClientModInitializer {
 	// ==================== VARIABLES ==================== \\
 	public static final Logger LOGGER = LoggerFactory.getLogger("VexonClient");
+	public static final EventBus EVENT_BUS = new EventBus();
 
 	// ==================== METHODS ==================== \\
 	@Override

--- a/src/client/java/vexonclient/events/Event.java
+++ b/src/client/java/vexonclient/events/Event.java
@@ -1,0 +1,17 @@
+package vexonclient.events;
+
+/**
+ * Simple base class for events that can be cancelled.
+ * <p>Event handlers may call {@link #setCancelled(boolean)} to stop
+ * further processing if the event supports cancellation.
+ */
+public abstract class Event {
+    private boolean cancelled = false;
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+}

--- a/src/client/java/vexonclient/events/EventBus.java
+++ b/src/client/java/vexonclient/events/EventBus.java
@@ -1,0 +1,45 @@
+package vexonclient.events;
+
+import java.lang.reflect.Method;
+import java.util.*;
+
+/**
+ * EventBus for registering listener objects and firing events.
+ *
+ * <p>Listeners are methods annoted with {@link EventListener} that take a single parameter
+ * extending {@link Event}. Registering an object will automatically discover all such methods
+ * and store them for fast event dispatch.
+ */
+public class EventBus {
+    private final Map<Class<?>, List<Listener>> listeners = new HashMap<>();
+
+    /**
+     * Registers all listener methods of the given object.
+     * Only methods annotated with {@link EventListener} that take a single Event subclass
+     * parameter will be registered.
+     * @param object the object containing listener methods
+     */
+    public void register(Object object) {
+        for (Method method : object.getClass().getDeclaredMethods()) {
+            if (method.isAnnotationPresent(EventListener.class)
+                    && method.getParameterCount() == 1
+                    && Event.class.isAssignableFrom(method.getParameterTypes()[0])) {
+                method.setAccessible(true);
+                Class<?> eventType = method.getParameterTypes()[0];
+                listeners.computeIfAbsent(eventType, k -> new ArrayList<>()).add(new Listener(object, method));
+            }
+        }
+    }
+
+    /**
+     * Fires an event to all registered listeners for its class.
+     *
+     * @param event the event instance to dispatch
+     */
+    public void post(Event event) {
+        List<Listener> eventListeners = listeners.getOrDefault(event.getClass(), Collections.emptyList());
+        for (Listener listener : eventListeners) {
+            listener.invoke(event);
+        }
+    }
+}

--- a/src/client/java/vexonclient/events/EventBus.java
+++ b/src/client/java/vexonclient/events/EventBus.java
@@ -1,6 +1,7 @@
 package vexonclient.events;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.*;
 
 /**
@@ -36,10 +37,11 @@ public class EventBus {
      *
      * @param event the event instance to dispatch
      */
-    public void post(Event event) {
+    public Event post(Event event) {
         List<Listener> eventListeners = listeners.getOrDefault(event.getClass(), Collections.emptyList());
         for (Listener listener : eventListeners) {
             listener.invoke(event);
         }
+        return event;
     }
 }

--- a/src/client/java/vexonclient/events/EventListener.java
+++ b/src/client/java/vexonclient/events/EventListener.java
@@ -1,0 +1,10 @@
+package vexonclient.events;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface EventListener { }

--- a/src/client/java/vexonclient/events/Listener.java
+++ b/src/client/java/vexonclient/events/Listener.java
@@ -19,7 +19,7 @@ public class Listener {
 
     public void invoke(Event event) {
         try {
-            this.method.invoke(event);
+            this.method.invoke(owner, event);
         } catch (Exception e) {
             VexonClient.LOGGER.error("[Listener] {}", e.getMessage());
         }

--- a/src/client/java/vexonclient/events/Listener.java
+++ b/src/client/java/vexonclient/events/Listener.java
@@ -1,0 +1,27 @@
+package vexonclient.events;
+
+import vexonclient.VexonClient;
+
+import java.lang.reflect.Method;
+
+/**
+ * Used by the EventBus to invoke annotated methods
+ * on registered listener objects via reflection.
+ */
+public class Listener {
+    private final Object owner;
+    private final Method method;
+
+    public Listener(Object owner, Method method) {
+        this.owner = owner;
+        this.method = method;
+    }
+
+    public void invoke(Event event) {
+        try {
+            this.method.invoke(event);
+        } catch (Exception e) {
+            VexonClient.LOGGER.error("[Listener] {}", e.getMessage());
+        }
+    }
+}

--- a/src/client/java/vexonclient/events/vexon/KeyEvent.java
+++ b/src/client/java/vexonclient/events/vexon/KeyEvent.java
@@ -1,0 +1,35 @@
+package vexonclient.events.vexon;
+
+import org.lwjgl.glfw.GLFW;
+import vexonclient.events.Event;
+
+/**
+ * Represents a keyboard input event.
+ * Fired whenever a key is pressed or released.
+ */
+public class KeyEvent extends Event {
+    private final int key, scancode, action, modifiers;
+
+    public KeyEvent(int key, int scancode, int action, int modifiers) {
+        this.key = key;
+        this.scancode = scancode;
+        this.action = action;
+        this.modifiers = modifiers;
+    }
+
+    public int getKey() {
+        return key;
+    }
+    public int getScancode() {
+        return scancode;
+    }
+    public int getAction() {
+        return action;
+    }
+    public int getModifiers() {
+        return modifiers;
+    }
+    public boolean isPressed() {
+        return action == GLFW.GLFW_PRESS;
+    }
+}

--- a/src/client/java/vexonclient/mixins/KeyboardMixin.java
+++ b/src/client/java/vexonclient/mixins/KeyboardMixin.java
@@ -1,0 +1,20 @@
+package vexonclient.mixins;
+
+import net.minecraft.client.Keyboard;
+import org.lwjgl.glfw.GLFW;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vexonclient.VexonClient;
+import vexonclient.events.vexon.KeyEvent;
+
+@Mixin(Keyboard.class)
+public class KeyboardMixin {
+    @Inject(method = "onKey", at = @At("HEAD"), cancellable = true)
+    private void onKey(long window, int key, int scancode, int action, int modifiers, CallbackInfo ci) {
+        if (key == GLFW.GLFW_KEY_UNKNOWN || key == GLFW.GLFW_REPEAT) return;
+
+        if (VexonClient.EVENT_BUS.post(new KeyEvent(key, scancode, action, modifiers)).isCancelled()) ci.cancel();
+    }
+}

--- a/src/client/resources/vexon.client.mixins.json
+++ b/src/client/resources/vexon.client.mixins.json
@@ -1,9 +1,9 @@
 {
 	"required": true,
-	"package": "vexonclient.mixin",
+	"package": "vexonclient.mixins",
 	"compatibilityLevel": "JAVA_21",
 	"client": [
-
+		"KeyboardMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
This PR introduces the core EventBus system and adds keyboard input support via KeyboardMixin.

Changes:
- Event: base class for cancellable events
- Listener: wraps object/method pairs for reflective invocation
- EventBus: registers objects and posts event to methods annotatead with @EventListener
- KeyEvent: represents keyboard input events (key, scancode, action, modifiers)
- KeyboardMixin: fires KeyEvent when keys are pressed/released
- VexonClient: added EVENT_BUS instance for global access to the EventBus
- Mixins.json: registered KeyboardMixin for keyboard input