### PR TITLE
feat(event-bus): add GameJoinedEvent and Mixin

### DIFF
--- a/src/client/java/vexonclient/events/game/GameJoinedEvent.java
+++ b/src/client/java/vexonclient/events/game/GameJoinedEvent.java
@@ -1,0 +1,8 @@
+package vexonclient.events.game;
+
+import vexonclient.events.Event;
+
+/**
+ * Fired when the client enters a world/server
+ */
+public class GameJoinedEvent extends Event { }

--- a/src/client/java/vexonclient/mixins/ClientPlayNetworkHandlerMixin.java
+++ b/src/client/java/vexonclient/mixins/ClientPlayNetworkHandlerMixin.java
@@ -1,0 +1,18 @@
+package vexonclient.mixins;
+
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vexonclient.VexonClient;
+import vexonclient.events.game.GameJoinedEvent;
+
+@Mixin(ClientPlayNetworkHandler.class)
+public class ClientPlayNetworkHandlerMixin {
+    @Inject(method = "onGameJoin", at = @At("HEAD"))
+    private void onGameJoin(GameJoinS2CPacket packet, CallbackInfo ci) {
+        VexonClient.EVENT_BUS.post(new GameJoinedEvent());
+    }
+}

--- a/src/client/resources/vexon.client.mixins.json
+++ b/src/client/resources/vexon.client.mixins.json
@@ -3,6 +3,7 @@
 	"package": "vexonclient.mixins",
 	"compatibilityLevel": "JAVA_21",
 	"client": [
+		"ClientPlayNetworkHandlerMixin",
 		"KeyboardMixin"
 	],
 	"injectors": {


### PR DESCRIPTION
This PR adds a simple GameJoinedEvent to the EventBus system, fired whenever the client joins a world or server.

Changes:
- GameJoinedEvent: a plain event with no additional data, serves as a signal for world/server join events
- ClientPlayNetworkHandlerMixin: injects into onGameJoin to fire the GameJoinedEvent