### PR TITLE
feat(event-bus): add GameLeftEvent and Mixin

### DIFF
--- a/src/client/java/vexonclient/events/game/GameLeftEvent.java
+++ b/src/client/java/vexonclient/events/game/GameLeftEvent.java
@@ -1,0 +1,8 @@
+package vexonclient.events.game;
+
+import vexonclient.events.Event;
+
+/**
+ * Fired when the client leaves a world/server
+ */
+public class GameLeftEvent extends Event { }

--- a/src/client/java/vexonclient/mixins/MinecraftClientMixin.java
+++ b/src/client/java/vexonclient/mixins/MinecraftClientMixin.java
@@ -1,0 +1,18 @@
+package vexonclient.mixins;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vexonclient.VexonClient;
+import vexonclient.events.game.GameLeftEvent;
+
+@Mixin(MinecraftClient.class)
+public class MinecraftClientMixin {
+    @Inject(method = "disconnect", at = @At("HEAD"))
+    private void onDisconnect(Screen disconnectionScreen, boolean transferring, CallbackInfo ci) {
+        VexonClient.EVENT_BUS.post(new GameLeftEvent());
+    }
+}

--- a/src/client/resources/vexon.client.mixins.json
+++ b/src/client/resources/vexon.client.mixins.json
@@ -4,7 +4,8 @@
 	"compatibilityLevel": "JAVA_21",
 	"client": [
 		"ClientPlayNetworkHandlerMixin",
-		"KeyboardMixin"
+		"KeyboardMixin",
+		"MinecraftClientMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
This PR adds a simple GameLeftEvent to the EventBus system, fired whenever the client leaves a world or server.

Changes:
- GameLeftEvent: a plain event with no additional data, serves as a signal for world/server leave events
- MinecraftClientMixin: injects into disconnect to fire the GameLeftEvent