### PR TITLE
feat(event-bus): add TickEvent (pre/post)

### DIFF
--- a/src/client/java/vexonclient/events/game/TickEvent.java
+++ b/src/client/java/vexonclient/events/game/TickEvent.java
@@ -1,0 +1,8 @@
+package vexonclient.events.game;
+
+import vexonclient.events.Event;
+
+public class TickEvent extends Event {
+    public static class Pre extends TickEvent { }
+    public static class Post extends TickEvent { }
+}

--- a/src/client/java/vexonclient/mixins/ClientPlayNetworkHandlerMixin.java
+++ b/src/client/java/vexonclient/mixins/ClientPlayNetworkHandlerMixin.java
@@ -12,7 +12,7 @@ import vexonclient.events.game.GameJoinedEvent;
 @Mixin(ClientPlayNetworkHandler.class)
 public class ClientPlayNetworkHandlerMixin {
     @Inject(method = "onGameJoin", at = @At("HEAD"))
-    private void onGameJoin(GameJoinS2CPacket packet, CallbackInfo ci) {
+    private void onGameJoinPre(GameJoinS2CPacket packet, CallbackInfo ci) {
         VexonClient.EVENT_BUS.post(new GameJoinedEvent());
     }
 }

--- a/src/client/java/vexonclient/mixins/KeyboardMixin.java
+++ b/src/client/java/vexonclient/mixins/KeyboardMixin.java
@@ -12,7 +12,7 @@ import vexonclient.events.vexon.KeyEvent;
 @Mixin(Keyboard.class)
 public class KeyboardMixin {
     @Inject(method = "onKey", at = @At("HEAD"), cancellable = true)
-    private void onKey(long window, int key, int scancode, int action, int modifiers, CallbackInfo ci) {
+    private void onKeyPre(long window, int key, int scancode, int action, int modifiers, CallbackInfo ci) {
         if (key == GLFW.GLFW_KEY_UNKNOWN || key == GLFW.GLFW_REPEAT) return;
 
         if (VexonClient.EVENT_BUS.post(new KeyEvent(key, scancode, action, modifiers)).isCancelled()) ci.cancel();

--- a/src/client/java/vexonclient/mixins/MinecraftClientMixin.java
+++ b/src/client/java/vexonclient/mixins/MinecraftClientMixin.java
@@ -8,11 +8,31 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import vexonclient.VexonClient;
 import vexonclient.events.game.GameLeftEvent;
+import vexonclient.events.game.TickEvent;
 
 @Mixin(MinecraftClient.class)
 public class MinecraftClientMixin {
+    /**
+     * Fires GameLeftEvent
+     */
     @Inject(method = "disconnect", at = @At("HEAD"))
     private void onDisconnect(Screen disconnectionScreen, boolean transferring, CallbackInfo ci) {
         VexonClient.EVENT_BUS.post(new GameLeftEvent());
+    }
+
+    /**
+     * Fires TickEvent.Pre
+     */
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void onTickPre(CallbackInfo ci) {
+        VexonClient.EVENT_BUS.post(new TickEvent.Pre());
+    }
+
+    /**
+     * Fires TickEvent.Post
+     */
+    @Inject(method = "tick", at = @At("TAIL"))
+    private void onTickPost(CallbackInfo ci) {
+        VexonClient.EVENT_BUS.post(new TickEvent.Post());
     }
 }


### PR DESCRIPTION
This PR adds TickEvent (pre/post) to the EventBus for code that needs to run every tick.

Changes:
- TickEvent: fired each Minecraft tick (pre/post)
- MinecraftClientMixin: injects tick to fire TickEvent.Pre and TickEvent.Post
- Refactor KeyboardMixin and ClientPlayNetworkHandlerMixin for naming consistency