### PR TITLE
feat(event-bus): add MouseEvent

### DIFF
--- a/src/client/java/vexonclient/VexonClient.java
+++ b/src/client/java/vexonclient/VexonClient.java
@@ -1,16 +1,16 @@
 package vexonclient;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.minecraft.client.MinecraftClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import vexonclient.events.EventBus;
 
 public class VexonClient implements ClientModInitializer {
-	// ==================== VARIABLES ==================== \\
+	public static final MinecraftClient mc = MinecraftClient.getInstance();
 	public static final Logger LOGGER = LoggerFactory.getLogger("VexonClient");
 	public static final EventBus EVENT_BUS = new EventBus();
 
-	// ==================== METHODS ==================== \\
 	@Override
 	public void onInitializeClient() {
 		LOGGER.info("Vexon Client Started!");

--- a/src/client/java/vexonclient/events/game/TickEvent.java
+++ b/src/client/java/vexonclient/events/game/TickEvent.java
@@ -2,6 +2,9 @@ package vexonclient.events.game;
 
 import vexonclient.events.Event;
 
+/**
+ * Fired each Minecraft tick (Pre-tick and Post-tick)
+ */
 public class TickEvent extends Event {
     public static class Pre extends TickEvent { }
     public static class Post extends TickEvent { }

--- a/src/client/java/vexonclient/events/vexon/MouseEvent.java
+++ b/src/client/java/vexonclient/events/vexon/MouseEvent.java
@@ -1,0 +1,43 @@
+package vexonclient.events.vexon;
+
+import vexonclient.events.Event;
+
+/**
+ * Represents a mouse event.
+ * Fired whenever the mouse is clicked or moved.
+ */
+public class MouseEvent extends Event {
+    private final int button, action, x, y;
+
+    public MouseEvent(int button, int action, double x, double y) {
+        this.button = button;
+        this.action = action;
+        this.x = (int)x;
+        this.y = (int)y;
+    }
+
+    public int getButton() {
+        return button;
+    }
+    public int getAction() {
+        return action;
+    }
+    public int getX() {
+        return x;
+    }
+    public int getY() {
+        return y;
+    }
+    public boolean isLeftClick() {
+        return button == 0 && action == 1;
+    }
+    public boolean isRightClick() {
+        return button == 1 && action == 1;
+    }
+    public boolean isMiddleClick() {
+        return button == 2 && action == 1;
+    }
+    public boolean isReleased() {
+        return action == 0;
+    }
+}

--- a/src/client/java/vexonclient/mixins/MouseMixin.java
+++ b/src/client/java/vexonclient/mixins/MouseMixin.java
@@ -1,0 +1,21 @@
+package vexonclient.mixins;
+
+import net.minecraft.client.Mouse;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vexonclient.VexonClient;
+import vexonclient.events.vexon.MouseEvent;
+
+@Mixin(Mouse.class)
+public class MouseMixin {
+    /**
+     * Fires MouseEvent
+     */
+    @Inject(method = "onMouseButton", at = @At("HEAD"), cancellable = true)
+    private void onMouseButtonPre(long window, int button, int action, int mods, CallbackInfo ci) {
+        MouseEvent event = new MouseEvent(button, action, VexonClient.mc.mouse.getX(), VexonClient.mc.mouse.getY());
+        if (VexonClient.EVENT_BUS.post(event).isCancelled()) ci.cancel();
+    }
+}

--- a/src/client/resources/vexon.client.mixins.json
+++ b/src/client/resources/vexon.client.mixins.json
@@ -5,7 +5,8 @@
 	"client": [
 		"ClientPlayNetworkHandlerMixin",
 		"KeyboardMixin",
-		"MinecraftClientMixin"
+		"MinecraftClientMixin",
+		"MouseMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
This PR adds MouseEvent to the EventBus which makes it easy to perform actions every MouseClick.

Added:
- MouseEvent: fired each time client clicks or releases mouse button
- MouseMixin: injects onMouseButton to fire MouseEvent
- VexonClient: add static reference to MinecraftClient
- Refactored TickEvent for naming consistency